### PR TITLE
Support rendering when [itemWidth] has not been defined

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/components/virtual-scroll/virtual-scroll.component.ts
@@ -294,7 +294,7 @@ export class VirtualScroll<T> implements VirtualScrollState<T> {
         this.afterViewInit$.pipe(
             switchMapTo(this.scrollStateChange),
             // Skip updates if we're ignoring scroll updates or item info isn't defined
-            filter(([, , , itemWidth, itemHeight]) => !this.renderingViews && !!itemWidth && !!itemHeight)
+            filter(([, , , itemWidth, itemHeight]) => !this.renderingViews && ((!!itemWidth || !this.gridList) && !!itemHeight)),
         ).subscribe(([
             ,
             scrollPosition,


### PR DESCRIPTION
Since only itemHeight is required for rendering when 'gridList' is false, the virtual-scroll component should probably reflect that in its rendering logic. Let me know if I've misunderstood how this is supposed to work!