### PR TITLE
fix viewCache for gridList (resolves issue #32)

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.component.ts
+++ b/src/components/virtual-scroll/virtual-scroll.component.ts
@@ -321,7 +321,13 @@ export class VirtualScroll<T> implements VirtualScrollState<T> {
             const bufferLengthPx = (scrollContainer.clientHeight) * bufferLength;
 
             // Calculate the number of rendered items per row
-            const itemsPerRow = gridList ? Math.floor(scrollContainer.clientWidth / itemWidth!) : 1;
+            let itemsPerRow = gridList ? Math.floor(scrollContainer.clientWidth / itemWidth!) : 1;
+
+            // Don't reset items per row to 0 on view change as it invalidates the viewCache
+            if (itemsPerRow === 0 && this._itemsPerRow > 0) {
+                itemsPerRow = this._itemsPerRow;
+            }
+
             const virtualScrollHeight = items.length * itemHeight! / itemsPerRow;
 
             // Adjust the bounds by the buffer length and clamp to the edges of the container


### PR DESCRIPTION
Resolves #32 

If you look at the itemsPerRow calculation you can see that for listview it is always 1.  For grid view it is a calculation that relies upon clientWidth.

When you navigate from a list to a detail page for example, the virtualscroll element is hidden so clientWidth changes to 0.  When you navigate back to your list you get a scroll to a random location and don't benefit from the view cache as the change in itemsPerRow from x to 0 and back to x as the virtualscroll element goes visible -> invisible -> visible again causes a change and invalidates the cache.

Only applies when the private _itemsPerRow is already a value greater than 0.

Have tested in a couple of my own apps and it's working great now when I navigate back from a detail view with gridlist enabled I get the cached view exactly as it was which is perfect!  Have not seen any issues or side effects and wouldn't expect to as this only catches the case where clientWidth goes to 0, in which case the old logic would show nothing anyway.